### PR TITLE
Ticket #5951: Add the loading animation only when it has a link

### DIFF
--- a/app/assets/sass/_embed.scss
+++ b/app/assets/sass/_embed.scss
@@ -201,7 +201,7 @@ $embed--translation-border: 3px solid $bridge-orange;
   @extend %embed--translator-annotation;
 }
 
-.bridgeEmbed__item .bridgeEmbed__item-pender-card {
+.bridgeEmbed__item .bridgeEmbed__item-pender-card-loading {
   @extend %loading;
 }
 

--- a/app/views/medias/_item.html.erb
+++ b/app/views/medias/_item.html.erb
@@ -30,6 +30,7 @@
     <div class="bridgeEmbed__item-pender-card rendered">
     <% else %>
     <div class="bridgeEmbed__item-pender-card" data-src="<%= BRIDGE_CONFIG['pender_base_view_url'] || BRIDGE_CONFIG['pender_base_url'] %>/api/medias.js?url=<%= entry[:link] %>">
+      <div class="bridgeEmbed__item-pender-card-loading"></div>
     <% end %>
       <%= entry[:source_text].blank? ? entry[:title] : entry[:source_text] %>
     </div>

--- a/public/stylesheets/bridge.css
+++ b/public/stylesheets/bridge.css
@@ -20,7 +20,7 @@ em {
   margin: 0;
   padding: 0; }
 
-.bridgeEmbed__item .bridgeEmbed__item-pender-card {
+.bridgeEmbed__item .bridgeEmbed__item-pender-card-loading {
   display: block;
   width: 20px;
   height: 20px;


### PR DESCRIPTION
The animation indicating that the content is loading will only be
displayed when the item have a link.